### PR TITLE
prevent cross model visits

### DIFF
--- a/app/controllers/concerns/accessible.rb
+++ b/app/controllers/concerns/accessible.rb
@@ -1,0 +1,27 @@
+# https://github.com/plataformatec/devise/
+# wiki/How-to-Setup-Multiple-Devise-User-Models
+
+module Accessible
+  extend ActiveSupport::Concern
+  included do
+    before_action :check_user
+  end
+
+  protected
+  def check_user
+    if current_counsellor
+      flash.clear
+      # if counsellor tries to visit user page, redicrect to counsellor dashboard
+      # currently redirect to home page as there is no dash board view
+      # redirect_to(rails_admin.dashboard_path) && return
+      redirect_to(root_path) && return
+    elsif current_user
+      flash.clear
+      # The authenticated root path can be defined in your routes.rb in: devise_scope :user do...
+      # if counsellor tries to visit user page, redicrect to counsellor dashboard
+      # currently redirect to home page as there is no dash board view
+      # redirect_to(authenticated_user_root_path) && return
+      redirect_to(root_path) && return
+    end
+  end
+end

--- a/app/controllers/counsellors/registrations_controller.rb
+++ b/app/controllers/counsellors/registrations_controller.rb
@@ -1,6 +1,7 @@
 class Counsellors::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
+  include Accessible
 
   # GET /resource/sign_up
   # def new

--- a/app/controllers/counsellors/sessions_controller.rb
+++ b/app/controllers/counsellors/sessions_controller.rb
@@ -1,5 +1,10 @@
 class Counsellors::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  
+  # You must skip_before_action for the destroy action in each SessionsController 
+  # to prevent the redirect to happen before the sign out occurs.
+  include Accessible
+  skip_before_action :check_user, only: :destroy
 
   # GET /resource/sign_in
   # def new

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,7 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
+  include Accessible
 
   # GET /resource/sign_up
   # def new

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,11 @@
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
 
+  # You must skip_before_action for the destroy action in each SessionsController 
+  # to prevent the redirect to happen before the sign out occurs.
+  include Accessible
+  skip_before_action :check_user, only: :destroy
+  
   # GET /resource/sign_in
   # def new
   #   super


### PR DESCRIPTION
complete [devise set up for multiple model](https://github.com/plataformatec/devise/wiki/How-to-Setup-Multiple-Devise-User-Models), confirmed when login as user and visit counsellor sign up/sign in, redirct to home page and vice-versa as cousellor login . Not checked in other views as not available yet.